### PR TITLE
Add centered title bar to Dylan page

### DIFF
--- a/dylan/css/styles.css
+++ b/dylan/css/styles.css
@@ -8,6 +8,7 @@ body {
   color: #222;
   margin: 0;
   padding: 0;
+  padding-top: 60px; /* offset for fixed title bar */
 }
 
 /* 3. Page Title */
@@ -64,4 +65,36 @@ hr {
     margin-bottom: 1.5rem;  /* adjust spacing below date as needed */
     font-size: 0.9rem;
     font-style: italic;
+}
+
+/* 6. Title Bar Layout */
+.title-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  z-index: 1000;
+}
+
+.title-bar .title-text {
+  font-weight: 600;
+  font-size: 1.2rem;
+}
+
+.title-bar .tab-link {
+  text-decoration: none;
+  color: inherit;
+  padding: 0.25rem 0.5rem;
+  transition: color 0.3s ease;
+}
+
+.title-bar .tab-link:hover {
+  color: #3498db;
 }

--- a/dylan/index.html
+++ b/dylan/index.html
@@ -8,6 +8,11 @@
   <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
+    <header class="title-bar">
+        <a href="#projects" class="tab-link">Projects</a>
+        <div class="title-text">Dylan Duecaster</div>
+        <a href="#about" class="tab-link">About</a>
+    </header>
     <h1>Project Blog</h1>
     <hr>
     <div id="posts-container"></div>


### PR DESCRIPTION
## Summary
- add fixed title bar with links and centered name on Dylan's blog
- adjust body padding to account for fixed header
- style links for hover effect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68627a08753c8333a157ac9d52025096