### PR TITLE
Enhance Dylan subpage layouts

### DIFF
--- a/dylan/contact/index.html
+++ b/dylan/contact/index.html
@@ -39,22 +39,43 @@
       <div class="hero-inner">
         <h1>Contact</h1>
         <p class="lede">Best way to reach me is email. Happy to talk robotics, autonomy, and vision-first products.</p>
+        <div class="page-hero-grid">
+          <div class="info-card">
+            <p class="info-label">Response time</p>
+            <p>Typically within 1–2 business days. If it is urgent, mention a deadline in the subject line.</p>
+          </div>
+          <div class="info-card">
+            <p class="info-label">Location</p>
+            <p>Greater St. Louis, open to remote collaboration and occasional travel for field tests.</p>
+          </div>
+          <div class="info-card">
+            <p class="info-label">Best fit</p>
+            <p>Early prototypes, systems integration, and product research at the intersection of hardware + AI.</p>
+          </div>
+        </div>
       </div>
     </section>
 
     <section class="section">
       <div class="contact-card">
-        <div>
-          <h2>Email</h2>
-          <p><a href="mailto:dylan@duecaster.com">dylan@duecaster.com</a></p>
-        </div>
-        <div>
-          <h2>Links</h2>
-          <div class="footer-links">
-            <a href="https://www.linkedin.com/in/dylanduecaster/">LinkedIn</a>
-            <a href="https://github.com/djduecaster">GitHub</a>
+        <div class="contact-grid">
+          <div class="contact-item">
+            <h2>Email</h2>
+            <p><a href="mailto:dylan@duecaster.com">dylan@duecaster.com</a></p>
           </div>
-        </div>      </div>
+          <div class="contact-item">
+            <h2>Topics</h2>
+            <p>Robotics behaviors, vision pipelines, autonomy tooling, and iOS companion experiences.</p>
+          </div>
+          <div class="contact-item">
+            <h2>Links</h2>
+            <div class="footer-links">
+              <a href="https://www.linkedin.com/in/dylanduecaster/">LinkedIn</a>
+              <a href="https://github.com/djduecaster">GitHub</a>
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
   </main>
 

--- a/dylan/css/styles.css
+++ b/dylan/css/styles.css
@@ -282,6 +282,75 @@ h1 {
   padding: 3.5rem 1.5rem 1.5rem;
 }
 
+.page-hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1.75rem;
+}
+
+.info-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.info-label {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.7rem;
+  color: var(--muted);
+  margin: 0 0 0.75rem;
+}
+
+.info-card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.pill-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pill-list li {
+  background: #1a1a1a;
+  color: #e6e6e6;
+  border: 1px solid var(--border);
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+}
+
+.section-kicker {
+  color: var(--muted);
+  font-size: 0.9rem;
+  max-width: 720px;
+}
+
+.callout-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.callout-item h3 {
+  margin: 0 0 0.5rem;
+}
+
+.callout-item p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
 .posts-container {
   max-width: 900px;
   margin: 0 auto;
@@ -352,6 +421,21 @@ h1 {
   border-radius: 16px;
   padding: 2rem;
   box-shadow: var(--shadow);
+}
+
+.contact-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-item h2 {
+  margin: 0 0 0.5rem;
+}
+
+.contact-item p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
 }
 
 .site-footer {

--- a/dylan/projects/index.html
+++ b/dylan/projects/index.html
@@ -39,6 +39,47 @@
       <div class="hero-inner">
         <h1>Projects</h1>
         <p class="lede">Selected work across robotics, vision, and iOS. Proof-forward, detail-rich, and iterated in public.</p>
+        <div class="page-hero-grid">
+          <div class="info-card">
+            <p class="info-label">Focus areas</p>
+            <ul class="pill-list">
+              <li>Robotics</li>
+              <li>Autonomy</li>
+              <li>Computer Vision</li>
+              <li>iOS Systems</li>
+              <li>Embedded Controls</li>
+            </ul>
+          </div>
+          <div class="info-card">
+            <p class="info-label">Current build</p>
+            <p>Expressive robotic lamp with Jetson inference, STM32 control loops, and a behavior state machine for responsive motion.</p>
+          </div>
+          <div class="info-card">
+            <p class="info-label">Collaboration</p>
+            <p>Open to early-stage prototypes, field tests, and systems design partnerships that need quick iteration and clear proof points.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-header">
+        <h2>How I build</h2>
+        <p class="section-kicker">Each project focuses on tangible outcomes: system architecture, measurable performance, and a documented path to the next iteration.</p>
+      </div>
+      <div class="callout-grid">
+        <div class="callout-item">
+          <h3>System-first planning</h3>
+          <p>Define interfaces and constraints early so software, hardware, and controls stay aligned through integration.</p>
+        </div>
+        <div class="callout-item">
+          <h3>Prototype → proof</h3>
+          <p>Ship working demos quickly, then pressure-test assumptions with real data, metrics, and usability feedback.</p>
+        </div>
+        <div class="callout-item">
+          <h3>Documented iteration</h3>
+          <p>Capture architecture decisions, experiment results, and next steps so progress stays visible and repeatable.</p>
+        </div>
       </div>
     </section>
 

--- a/dylan/resume/index.html
+++ b/dylan/resume/index.html
@@ -40,6 +40,25 @@
         <h1>Resume</h1>
         <p class="lede">Systems engineer with aerospace training and a hands-on focus on robotics, autonomy, and software-heavy systems.</p>
         <a class="btn primary" href="#" aria-disabled="true">Download PDF (coming soon)</a>
+        <div class="page-hero-grid">
+          <div class="info-card">
+            <p class="info-label">Location</p>
+            <p>Greater St. Louis · Open to remote-friendly collaboration.</p>
+          </div>
+          <div class="info-card">
+            <p class="info-label">Core strengths</p>
+            <ul class="pill-list">
+              <li>Systems Integration</li>
+              <li>Trade Studies</li>
+              <li>Robotics Prototyping</li>
+              <li>Vision + ML</li>
+            </ul>
+          </div>
+          <div class="info-card">
+            <p class="info-label">Looking for</p>
+            <p>Teams shipping autonomy-driven products that need disciplined systems engineering and rapid prototyping.</p>
+          </div>
+        </div>
       </div>
     </section>
 

--- a/dylan/writing/index.html
+++ b/dylan/writing/index.html
@@ -39,10 +39,34 @@
       <div class="hero-inner">
         <h1>Writing / Build Logs</h1>
         <p class="lede">Short, technical notes on what I am building and how I think about systems.</p>
+        <div class="page-hero-grid">
+          <div class="info-card">
+            <p class="info-label">Topics</p>
+            <ul class="pill-list">
+              <li>Robotics</li>
+              <li>Vision Pipelines</li>
+              <li>iOS + Swift</li>
+              <li>Systems Thinking</li>
+              <li>Prototyping</li>
+            </ul>
+          </div>
+          <div class="info-card">
+            <p class="info-label">Cadence</p>
+            <p>Notes are written at key milestones: experiments, architecture decisions, and post-demo learnings.</p>
+          </div>
+          <div class="info-card">
+            <p class="info-label">Usefulness</p>
+            <p>Expect implementation details, constraints, and what I would do differently in the next iteration.</p>
+          </div>
+        </div>
       </div>
     </section>
 
     <section class="section">
+      <div class="section-header">
+        <h2>Latest entries</h2>
+        <p class="section-kicker">Each entry links to a full build log with diagrams, code notes, and next steps.</p>
+      </div>
       <div id="posts-container" class="posts-container"></div>
     </section>
   </main>


### PR DESCRIPTION
### Motivation
- Improve scanability of the Dylan subpages by surfacing short, high‑value details in the hero areas. 
- Provide consistent micro-layout components (info cards, pill lists, callouts) to reduce visual clutter and make intent explicit. 
- Make the Contact and Resume pages more actionable for collaborators by adding expectations and quick‑glance strengths.

### Description
- Added shared layout styles in `dylan/css/styles.css` for `.page-hero-grid`, `.info-card`, `.info-label`, `.pill-list`, `.callout-grid`, `.section-kicker`, `.contact-grid`, and `.contact-item` to support new hero micro-components. 
- Updated `dylan/projects/index.html` to include a hero info grid and a new callout section explaining the process (`System-first planning`, `Prototype → proof`, `Documented iteration`). 
- Updated `dylan/writing/index.html` to add a hero info grid (topics, cadence, usefulness) and a `Latest entries` section header above the posts container. 
- Updated `dylan/resume/index.html` to add a hero info grid with `Location`, `Core strengths`, and `Looking for` cards. 
- Updated `dylan/contact/index.html` to add hero info cards (response time, location, best fit) and reorganize contact content into a `contact-grid` with `contact-item` blocks.

### Testing
- Served the site locally with `python -m http.server` and captured a full-page screenshot of the Projects page using a Playwright script, producing the artifact `artifacts/dylan-projects.png`, which completed successfully. 
- Verified the changed files are staged and committed (`git commit` succeeded with the message "Enhance Dylan subpage layouts"). 
- No unit tests were required for these static content and CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983621f57148333a15a34f3e2ec7fd3)